### PR TITLE
fix: add a border to mdbook item frames to make the distinction between them more visible

### DIFF
--- a/src/handlebars/mdbook/module.hbs
+++ b/src/handlebars/mdbook/module.hbs
@@ -3,7 +3,7 @@
 ```Namespace: {{namespace}}```
 
 {{#each items as |item|}}
-<div style='box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2); padding: 15px; border-radius: 5px;'>
+<div style='box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2); padding: 15px; border-radius: 5px; border: 1px solid var(--theme-hover)'>
     <h2 class="func-name"> <code>{{item.type}}</code> {{item.name}} </h2>
 
 ```rust,ignore


### PR DESCRIPTION
Add border style to wrapping div for module.item to make it easier to see. Fixes #24 