### PR TITLE
fix: include missing final section for items when not using `ItemsOrder::ByIndex`

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -266,6 +266,13 @@ impl Section {
             false
         });
 
+        if !current_body.is_empty() {
+            sections.push(Self {
+                name: std::mem::take(&mut current_name),
+                body: Item::format_comments(&current_body[..]),
+            });
+        }
+
         sections
     }
 }


### PR DESCRIPTION
Add check for current_body when parsing sections to include the final section. Fixes #22 