### PR TITLE
fix: code block at end of sections breaking markdown

### DIFF
--- a/src/handlebars/mdbook/module.hbs
+++ b/src/handlebars/mdbook/module.hbs
@@ -18,6 +18,7 @@
 <button group="{{item.name}}" id="link-{{item.name}}-{{section.name}}" {{#if @first}} class="tablinks active" {{else}} class="tablinks" {{/if}}
     onclick="openTab(event, '{{item.name}}', '{{section.name}}')">
 {{> ContentPartial content=section.name}}
+
 </button>
 {{/each}}
 </div>
@@ -26,6 +27,7 @@
 {{#each sections as |section|}}
 <div group="{{item.name}}" id="{{item.name}}-{{section.name}}" class="tabcontent" {{#if @first}} style="display: block;" {{else}} style="display: none;" {{/if}}>
 {{> ContentPartial content=section.body}}
+
 </div>
 {{/each}}
 


### PR DESCRIPTION
If triple back tick (tilde) is at the end of a section it is concatenated with a closing tag. This becomes invalid markdown. This PR updates the template for `mdbook` to add a newline between the end of the section and buttons and the content rendered. This makes it more robust and less likely to break based on syntax. Fixes #23 