### PR TITLE
fix: `# rhai-autodocs:index:x` is not longer mistaken for a documentation section anymore

### DIFF
--- a/examples/docusaurus/docusaurus-example/docs/rhai-autodocs/global.mdx
+++ b/examples/docusaurus/docusaurus-example/docs/rhai-autodocs/global.mdx
@@ -21,7 +21,6 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
-
 ## <code>get/set</code> Tragedy.age {#getset-Tragedy.age}
 
 ```js
@@ -42,7 +41,6 @@ set Tragedy.age = int
     </TabItem>
 </Tabs>
 
-
 ## <code>get/set</code> Tragedy.name {#getset-Tragedy.name}
 
 ```js
@@ -61,7 +59,6 @@ get Tragedy.name -> string
     </TabItem>
 </Tabs>
 
-
 ## <code>fn</code> new_romeo {#fn-new_romeo}
 
 ```js
@@ -75,7 +72,6 @@ fn new_romeo() -> Tragedy
     </TabItem>
 </Tabs>
 
-
 ## <code>fn</code> new_juliet {#fn-new_juliet}
 
 ```js
@@ -88,7 +84,6 @@ fn new_juliet() -> Tragedy
         build a new Juliet character
     </TabItem>
 </Tabs>
-
 
 ## <code>index get/set</code> Tragedy.int {#indexgetset-Tragedy.int}
 
@@ -111,4 +106,3 @@ index set Tragedy[_: int] = ?
         ```
     </TabItem>
 </Tabs>
-

--- a/examples/docusaurus/docusaurus-example/docs/rhai-autodocs/my_module.mdx
+++ b/examples/docusaurus/docusaurus-example/docs/rhai-autodocs/my_module.mdx
@@ -30,7 +30,6 @@ fn hello_world(message: String)
     </TabItem>
 </Tabs>
 
-
 ## <code>fn</code> add {#fn-add}
 
 ```js
@@ -55,7 +54,6 @@ fn add(a: int, b: int) -> int
     </TabItem>
 </Tabs>
 
-
 ## <code>type</code> NewType {#type-NewType}
 
 
@@ -65,4 +63,3 @@ fn add(a: int, b: int) -> int
         A new type that does stuff.
     </TabItem>
 </Tabs>
-

--- a/src/item.rs
+++ b/src/item.rs
@@ -246,7 +246,7 @@ impl Section {
 
             match line.split_once("# ") {
                 Some((_prefix, name))
-                    if !in_code_block && line.find(RHAI_ITEM_INDEX_PATTERN).is_none() =>
+                    if !in_code_block && !line.contains(RHAI_ITEM_INDEX_PATTERN) =>
                 {
                     sections.push(Self {
                         name: std::mem::take(&mut current_name),

--- a/src/item.rs
+++ b/src/item.rs
@@ -239,19 +239,19 @@ impl Section {
         let mut in_code_block = false;
 
         // Start by extracting all sections from markdown comments.
-        docs.lines().fold(true, |first, line| {
+        docs.lines().for_each(|line| {
             if line.split_once("```").is_some() {
                 in_code_block = !in_code_block;
             }
 
             match line.split_once("# ") {
-                Some((_prefix, name)) if !in_code_block => {
-                    if !first {
-                        sections.push(Self {
-                            name: std::mem::take(&mut current_name),
-                            body: Item::format_comments(&current_body[..]),
-                        });
-                    }
+                Some((_prefix, name))
+                    if !in_code_block && line.find(RHAI_ITEM_INDEX_PATTERN).is_none() =>
+                {
+                    sections.push(Self {
+                        name: std::mem::take(&mut current_name),
+                        body: Item::format_comments(&current_body[..]),
+                    });
 
                     current_name = name.to_string();
                     current_body = vec![];
@@ -261,9 +261,7 @@ impl Section {
                 Some(_) => {}
                 // Append regular lines.
                 None => current_body.push(format!("{line}\n")),
-            };
-
-            false
+            }
         });
 
         sections


### PR DESCRIPTION
following #26