### PR TITLE
Fix hash sign in code making the line invisible

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -256,11 +256,7 @@ impl Section {
                     current_name = name.to_string();
                     current_body = vec![];
                 }
-                // Do not append lines of code that starts with the '#' token,
-                // which are removed on rust docs automatically.
-                Some(_) => {}
-                // Append regular lines.
-                None => current_body.push(format!("{line}\n")),
+                Some(_) | None => current_body.push(format!("{line}\n")),
             }
         });
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -239,6 +239,7 @@ fn hello_world()
     <TabItem value="Description" default>
 
         A function that prints to stdout.
+
     </TabItem>
 </Tabs>
 
@@ -252,6 +253,7 @@ fn add(a: int, b: int) -> int
     <TabItem value="Description" default>
 
         A function that adds two integers together.
+
     </TabItem>
 </Tabs>
 "#


### PR DESCRIPTION
This PR fixes the fact that if there's a hash somewhere in a line in a code block, surrounded by spaces, the line was hidden.
Proper hidden lines still behave as expected.


